### PR TITLE
Create session handlers to deal with disconection

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -207,7 +207,6 @@ export default class Client {
 
     // close :: Promise ()
     close() {
-        console.log('Closing', this._closing, this._clientChannel.state);
         this._closing = true;
 
         if (this._clientChannel.state === Lime.SessionState.ESTABLISHED) {
@@ -217,11 +216,7 @@ export default class Client {
         return Promise.resolve(
             this.sessionPromise
                 .then(s =>  s)
-                .catch(s => {
-                    this.sessionFinishedHandlers.unshift();
-                    this.sessionFinishedHandlers.forEach(handler => handler(s));
-                    return Promise.resolve(s);
-                })
+                .catch(s => Promise.resolve(s))
         );
     }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -131,10 +131,14 @@ export default class Client {
         };
 
         this.sessionPromise = new Promise((resolve, reject) => {
-            this.sessionFinishedHandlers.unshift(resolve);
-            this.sessionFailedHandlers.unshift(reject);
-            this._clientChannel.onSessionFinished = (s) => this.sessionFinishedHandlers.forEach(handler => handler(s));
-            this._clientChannel.onSessionFailed = (s) => this.sessionFailedHandlers.forEach(handler => handler(s));
+            this._clientChannel.onSessionFinished = (s) => {
+                resolve(s);
+                this.sessionFinishedHandlers.forEach(handler => handler(s));
+            };
+            this._clientChannel.onSessionFailed = (s) => {
+                reject(s);
+                this.sessionFailedHandlers.forEach(handler => handler(s));
+            };
         });
     }
 
@@ -228,7 +232,7 @@ export default class Client {
 
         return Promise.resolve(
             this.sessionPromise
-                .then(s =>  s)
+                .then(s => s)
                 .catch(s => Promise.resolve(s))
         );
     }

--- a/test/blipSdkClientTest.js
+++ b/test/blipSdkClientTest.js
@@ -401,6 +401,25 @@ describe('Client', function () {
         });
     });
 
+    it('should receive a finished session on promise and on handler', (done) => {
+        this.client
+            .connectWithKey('test', 'YWJjZGVm')
+            .then(() => this.client.sendCommand({ id: 'test', method: 'set', uri: '/kill' }));
+
+        let handlersCalled = 0;
+        this.client.sessionPromise
+            .then((s) => {
+                s.state.should.equal('finished');
+                handlersCalled++;
+                handlersCalled.should.equals(2);
+                done();
+            });
+        this.client.addSessionFinishedHandlers((s) => {
+            s.state.should.equal('finished');
+            handlersCalled++;
+        });
+    });
+
     it('should received a failed session', (done) => {
         this.client
             .connectWithKey('test', 'YWJjZGVm')
@@ -430,6 +449,29 @@ describe('Client', function () {
             s.reason.code.should.equal(11);
             this.client.close();
             done();
+        });
+    });
+
+    it('should received a failed session on promise and on handler', (done) => {
+        this.client
+            .connectWithKey('test', 'YWJjZGVm')
+            .then(() => this.client.sendCommand({ id: 'test', method: 'set', uri: '/killWithFail' }));
+
+        let handlersCalled = 0;
+        this.client
+            .sessionPromise
+            .catch((s) => {
+                s.state.should.equal('failed');
+                s.reason.code.should.equal(11);
+                handlersCalled++;
+                handlersCalled.should.equals(2);
+                done();
+            });
+        this.client.addSessionFailedHandlers((s) => {
+            s.state.should.equal('failed');
+            s.reason.code.should.equal(11);
+            handlersCalled++;
+            this.client.close();
         });
     });
 

--- a/test/blipSdkClientTest.js
+++ b/test/blipSdkClientTest.js
@@ -438,7 +438,7 @@ describe('Client', function () {
             .connectWithKey('test', 'YWJjZGVm')
             .then(() => this.client.sendCommand({ id: 'test', method: 'set', uri: '/killWithFail' }));
 
-        this.client.addSessionFinishedHandlers((s) => {
+        this.client.addSessionFinishedHandlers(() => {
             throw new Error('Should not call this handler');
         });
         this.client.addSessionFailedHandlers((s) => {

--- a/test/blipSdkClientTest.js
+++ b/test/blipSdkClientTest.js
@@ -379,6 +379,17 @@ describe('Client', function () {
             });
     });
 
+    it('should receive a finished session on handler', (done) => {
+        this.client
+            .connectWithKey('test', 'YWJjZGVm')
+            .then(() => this.client.sendCommand({ id: 'test', method: 'set', uri: '/kill' }));
+
+        this.client.addSessionFinishedHandlers((s) => {
+            s.state.should.equal('finished');
+            done();
+        });
+    });
+
     it('should received a failed session', (done) => {
         this.client
             .connectWithKey('test', 'YWJjZGVm')
@@ -396,5 +407,24 @@ describe('Client', function () {
                 s.reason.code.should.equal(11);
                 done();
             });
+    });
+
+    it('should received a failed session on handler', (done) => {
+        this.client
+            .connectWithKey('test', 'YWJjZGVm')
+            .then(() => this.client.sendCommand({ id: 'test', method: 'set', uri: '/killWithFail' }));
+
+        this.client.addSessionFinishedHandlers((s) => {
+            this.client.clearSessionFinishedHandlers();
+            this.client.clearSessionFailedHandlers();
+            s.state.should.equal('failed');
+            s.reason.code.should.equal(11);
+            done();
+        });
+        this.client.addSessionFailedHandlers((s) => {
+            s.state.should.equal('failed');
+            s.reason.code.should.equal(11);
+            return this.client.close();
+        });
     });
 });


### PR DESCRIPTION
Create a `sessionFailedHandlers` and `sessionFinishedHandlers` on client to allow an external user to better handle disconnections and prevent overriding callbacks if client reconnect.