### PR TITLE
Add message internal id to notification metadata

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -124,7 +124,9 @@ export default class Client {
                     to: message.pp || message.from,
                     event: Lime.NotificationEvent.RECEIVED,
                     metadata: {
-                        '#message.to': message.to
+                        '#message.to': message.to,
+                        '#message.uniqueId': message.metadata ? message.metadata["$internalId"] || null : null
+
                     }
                 });
             }
@@ -201,7 +203,8 @@ export default class Client {
                 to: message.pp || message.from,
                 event: Lime.NotificationEvent.CONSUMED,
                 metadata: {
-                    '#message.to': message.to
+                    '#message.to': message.to,
+                    '#message.uniqueId': message.metadata ? message.metadata["$internalId"] || null : null
                 }
             });
         }

--- a/src/Client.js
+++ b/src/Client.js
@@ -125,7 +125,7 @@ export default class Client {
                     event: Lime.NotificationEvent.RECEIVED,
                     metadata: {
                         '#message.to': message.to,
-                        '#message.uniqueId': message.metadata ? message.metadata["$internalId"] || null : null
+                        '#message.uniqueId': message.metadata ? message.metadata['#uniqueId'] || null : null
 
                     }
                 });
@@ -204,7 +204,7 @@ export default class Client {
                 event: Lime.NotificationEvent.CONSUMED,
                 metadata: {
                     '#message.to': message.to,
-                    '#message.uniqueId': message.metadata ? message.metadata["$internalId"] || null : null
+                    '#message.uniqueId': message.metadata ? message.metadata['#uniqueId'] || null : null
                 }
             });
         }


### PR DESCRIPTION

We inserted this metadata to be able to back up messages and notifications without ID