### PR TITLE
Test AI provider credentials command added

### DIFF
--- a/src/Extensions/ArtificialIntelligence/ContentTypes.js
+++ b/src/Extensions/ArtificialIntelligence/ContentTypes.js
@@ -27,3 +27,5 @@ export const WORD_SET = 'application/vnd.iris.ai.word-set+json';
 export const WORD_SET_ANALYSIS = 'application/vnd.iris.ai.word-set-analysis+json';
 
 export const WORD_SET_WORD = 'application/vnd.iris.ai.word+json';
+
+export const PROVIDER_CONNECTION = 'application/vnd.iris.ai.provider-test-connection+json';

--- a/src/Extensions/ArtificialIntelligence/UriTemplates.js
+++ b/src/Extensions/ArtificialIntelligence/UriTemplates.js
@@ -45,3 +45,5 @@ export const CONTENT = '/content';
 export const CONTENT_ID = '/content/{0}';
 
 export const CONTENT_ANALYSIS = '/content/analysis';
+
+export const PROVIDER_TEST_CONNECTION = '/provider/test-connection';

--- a/src/Extensions/ArtificialIntelligence/index.js
+++ b/src/Extensions/ArtificialIntelligence/index.js
@@ -395,4 +395,11 @@ export default class ArtificialIntelligenceExtension extends ExtensionBase {
                 this._buildUri(UriTemplates.CONTENT_ID, id)));
     }
 
+    testProviderConnectionAsync(providerConnection) {
+        return this._processCommand(
+            this._createSetCommand(
+                this._buildUri(UriTemplates.PROVIDER_TEST_CONNECTION), ContentTypes.PROVIDER_CONNECTION, providerConnection
+            )
+        );
+    }
 }


### PR DESCRIPTION
A new command was implemented in AI Application to test saved credentials in the respective provider. So, this new command integration was implemented here.

[New command pull request on Iris](https://curupira.visualstudio.com/BLiP/_git/iris/pullrequest/20070?_a=overview)