### PR TITLE
Fixing azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,6 @@ extends:
     type: javascript
     to: semantic-release
     npmCmds:
-    - run: npm ci
-    - run: npm run bundle
-    - run: npm publish
+    - npm ci
+    - npm run bundle
+    - npm publish

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ resources:
   - repository: templates
     type: git
     name: Operações/template-take-blip
-    ref: refs/tags/v1.3.5
+    ref: refs/tags/v1.3.13
 
 extends:
   template: template-pipeline.yml@templates    

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,4 +23,3 @@ extends:
     npmCmds:
     - npm ci
     - npm run bundle
-    - npm publish

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:single": "./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli cover ./node_modules/mocha/bin/_mocha -- --recursive ./test -R spec",
     "test:check-coverage": "./node_modules/.bin/istanbul check-coverage",
     "test:upload-coverage": "cat ./coverage/lcov.info | codecov",
-    "semantic-release": "semantic-release --prepare && npm publish && semantic-release post",
+    "semantic-release": "semantic-release",
     "semantic-release-local": "semantic-release --prepare --debug=false && npm publish && semantic-release post --debug=false"
   },
   "repository": {


### PR DESCRIPTION
- Npm commands writing was fixed;
- Pipeline template version was updated to v1.3.13;
- "npm publish" was removed because the used template already runs "npm run semantic-release" at the end and this command includes "npm publish";
- Additional commands was removed from "semantic-release", on package.json, to prevent runtime error in pipeline template;