### PR TITLE
#826778 - adding deleted event

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -238,7 +238,8 @@ export default class Client {
                     'accepted',
                     'dispatched',
                     'received',
-                    'consumed'
+                    'consumed',
+                    'deleted'
                 ]
             }
         });

--- a/test/blipSdkClientTest.js
+++ b/test/blipSdkClientTest.js
@@ -125,7 +125,8 @@ describe('Client', function () {
                         'accepted',
                         'dispatched',
                         'received',
-                        'consumed'
+                        'consumed',
+                        'deleted'
                     ]
                 }
             });


### PR DESCRIPTION
In order to be able to listen to the new notification type for deleted messages, we are adding the new event to receipt call.